### PR TITLE
Replace apple game elements with orange equivalents

### DIFF
--- a/src/CatchGame.js
+++ b/src/CatchGame.js
@@ -97,7 +97,7 @@ export default function JaydenCatchGame() {
   const [fallingObjects, setFallingObjects] = useState([]);
   const [score, setScore] = useState(0);
   const [timeLeft, setTimeLeft] = useState(30);
-  const [message, setMessage] = useState("Let's go Jaden Rio! Catch them all! 🍎");
+  const [message, setMessage] = useState("Let's go Jaden Rio! Catch them all! 🍊");
   const [touchStartX, setTouchStartX] = useState(null);
 
   useEffect(() => {
@@ -213,11 +213,11 @@ export default function JaydenCatchGame() {
   return (
     <GameContainer>
       <Message>{message}</Message>
-      <Score>🍎 Score: {score}</Score>
+      <Score>🍊 Score: {score}</Score>
       <Timer>⏳ Time: {timeLeft}s</Timer>
       {fallingObjects.map((obj, index) => (
         <FallingObject key={index} x={obj.x} y={obj.y} type={obj.type}>
-          {obj.type === 'bad' ? '⚠️' : obj.type === 'bonus' ? '🌟' : '🍎'}
+          {obj.type === 'bad' ? '⚠️' : obj.type === 'bonus' ? '🌟' : '🍊'}
         </FallingObject>
       ))}
       <Basket className="basket" position={basketPosition} />


### PR DESCRIPTION
This PR replaces all apple-related game elements with orange equivalents.

Changes made:
- Changed the apple emoji (🍎) to orange emoji (🍊) in the game message
- Updated the score display to show orange emoji
- Changed the falling fruit from apple to orange

Impact on game functionality:
- No functional changes to game mechanics
- Only visual changes to replace apples with oranges
- Game scoring and mechanics remain the same
- Mobile responsiveness is preserved

Testing:
- Verified that all apple emojis have been replaced with orange emojis
- Confirmed that game mechanics continue to work as expected
- Tested on both desktop and mobile views
- Verified that score tracking works correctly with the new orange theme

Please review these changes and let me know if any adjustments are needed.