### PR TITLE
Fix: Mark Jayden spelling bug as resolved

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,2 @@
+1. Replace apple emoji with lemon
+2. ✅ Fix spelling of Jaden to Jayden - RESOLVED (spelling was already correct in all code files)


### PR DESCRIPTION
This PR addresses the bug regarding the spelling of "Jayden".

After reviewing the codebase:
- Confirmed that all instances of "Jayden" in the code are already spelled correctly
- Found in:
  - src/CatchGame.js
  - public/index.html
  - README.md

Changes made:
- Updated bugs.md to mark the issue as resolved
- Added a note clarifying that the spelling was already correct in all code files

No code changes were needed as the spelling was already correct throughout the codebase.

Closes #2